### PR TITLE
add small change to log likelihood

### DIFF
--- a/question1-5.tex
+++ b/question1-5.tex
@@ -402,7 +402,7 @@ L(\boldsymbol{\beta}) = \prod_{i=1}^n \pi_i^{Y_i}(1-\pi_i)^{1-Y_i}
 
 \begin{align}
 \ell(\boldsymbol{\beta}) &= \log L(\boldsymbol{\beta}) \\
-&= \sum_{i=1}^n \left[ Y_i \log\left(\frac{\pi_i}{1-\pi_i}\right) + \log(1-\pi_i) \right] \\
+&= \sum_{i=1}^n \left[ Y_i \log(\pi_i) + (1 - Y_i) \log(1 - \pi_i) \right] \\
 &= \sum_{i=1}^n \left[ Y_i \boldsymbol{\beta}^T\mathbf{x}_i - \log(1 + \exp(\boldsymbol{\beta}^T\mathbf{x}_i)) \right]
 \end{align}
 


### PR DESCRIPTION
This pull request includes a correction to the log-likelihood function in the `question1-5.tex` file. The change revises the mathematical formulation to properly account for the contributions of `Y_i` and `(1 - Y_i)` in the logarithmic terms.

Key change:

* `\subsubsection{Log-Likelihood Function}` in `question1-5.tex`: Corrected the summation formula for the log-likelihood function to replace `\log\left(\frac{\pi_i}{1-\pi_i}\right)` with separate terms for `\log(\pi_i)` and `\log(1 - \pi_i)`, ensuring proper representation of the likelihood components.